### PR TITLE
#28 GitHub. Action. Auto set 'approve' label when merged PR

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -1,0 +1,18 @@
+name: 'Auto set label "approve" after merge'
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    types: [closed]
+
+jobs:
+  add-label:
+    name: "Auto set label 'approve'"
+    if: ${{ github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label 'approve' to pull-request
+        uses: andymckay/labeler@master
+        with:
+          remove-labels: "awaiting review"
+          add-labels: "approve"


### PR DESCRIPTION
Added GitHub action for auto set 'approve' label when merged PR.